### PR TITLE
adds a parameter to running

### DIFF
--- a/doc/us/index.html
+++ b/doc/us/index.html
@@ -128,9 +128,13 @@ luarocks install coxpcall
 	<dt><strong><code>copcall(f, ...)</code></strong></dt>
 	<dd>Offers the same functionality as Lua <code>pcall(f, ...)</code>.</dd>
 
-	<dt><strong><code>running()</code></strong></dt>
-	<dd>Offers the same functionality as Lua <code>coroutine.running()</code>, but takes into 
-        account the extra coroutine created by <code>copcall</code> and <code>coxpcall</code>.</dd>
+	<dt><strong><code>running([coro])</code></strong></dt>
+        <dd>Because <code>coxpcall</code> and <code>copcall</code> run the function to protect 
+        inside a new coroutine, <code>coroutine.running()</code> will return an unexpected
+        coroutine when used inside the protected function. If the coroutine <code>coro</code> was 
+        created by the coxpcall module, then <code>running(coro)</code> will return the original 
+        coroutine that created it. If <code>coro</code> is not provided, it will default to the
+        currently running coroutine.</dd>
 </dl>
 
 <h2><a name="credits"></a>Credits</h2>

--- a/src/coxpcall.lua
+++ b/src/coxpcall.lua
@@ -56,9 +56,12 @@ function coxpcall(f, err, ...)
     return performResume(err, co, ...)
 end
 
-local function corunning()
-  local ok, coro = pcall(running)
-  if not ok then error(coro, 2) end
+local function corunning(coro)
+  if coro ~= nil then
+    assert(type(coro)=="thread", "Bad argument; expected thread, got: "..type(coro))
+  else
+    coro = running()
+  end
   while coromap[coro] do
     coro = coromap[coro]
   end


### PR DESCRIPTION
Allowing to patch only problem locations instead of monkey patching coroutine.running. But retains full compatibility with coroutine.running behaviour (so still can monkey patch).

Adds to https://github.com/keplerproject/coxpcall/pull/7 

Example:

``` lua
local cocall = require("coxpcall")

local myfunc = function(coro)
   coro = cocall.running(coro)   -- convert to original coroutine
   -- here do what needs to be done...
end
```
