### PR TITLE
Use native functions on Lua 5.3 as well.

### DIFF
--- a/src/coxpcall.lua
+++ b/src/coxpcall.lua
@@ -14,7 +14,7 @@
 -------------------------------------------------------------------------------
 
 -- Lua 5.2 makes this module a no-op
-if _VERSION == "Lua 5.2" then
+if _VERSION ~= "Lua 5.1" then
   copcall = pcall
   coxpcall = xpcall
   return { pcall = pcall, xpcall = xpcall, running = coroutine.running }


### PR DESCRIPTION
Similar to Lua 5.2 the native functions of Lua 5.3 support yielding without extra work.