### PR TITLE
Performance improvements.

### DIFF
--- a/rockspec/coxpcall-scm-1.rockspec
+++ b/rockspec/coxpcall-scm-1.rockspec
@@ -20,6 +20,6 @@ source = {
 }
 
 build = {
-   type = "bultin",
+   type = "builtin",
    modules = { coxpcall = "src/coxpcall.lua" }
 }

--- a/src/coxpcall.lua
+++ b/src/coxpcall.lua
@@ -36,12 +36,12 @@ end
 -- Implements xpcall with coroutines
 -------------------------------------------------------------------------------
 local performResume, handleReturnValue
-local oldpcall = pcall
+local oldpcall, oldxpcall = pcall, xpcall
 local pack = table.pack or function(...) return {n = select("#", ...), ...} end
 local unpack = table.unpack or unpack
 local running = coroutine.running
 local coromap = setmetatable({}, { __mode = "k" })
-  
+
 function handleReturnValue(err, co, status, ...)
     if not status then
         return false, err(debug.traceback(co, (...)), ...)
@@ -57,15 +57,32 @@ function performResume(err, co, ...)
     return handleReturnValue(err, co, coroutine.resume(co, ...))
 end
 
+local function id(trace, ...)
+    return trace
+end
+
 function coxpcall(f, err, ...)
-    local res, co = oldpcall(coroutine.create, f)
-    if not res then
-        local params = pack(...)
-        local newf = function() return f(unpack(params, 1, params.n)) end
-        co = coroutine.create(newf)
+    local current = running()
+    if not current then
+        if err == id then
+            return oldpcall(f, ...)
+        else
+            if select("#", ...) > 0 then
+                local oldf, params = f, pack(...)
+                f = function() return oldf(unpack(params, 1, params.n)) end
+            end
+            return oldxpcall(f, err)
+        end
+    else
+        local res, co = oldpcall(coroutine.create, f)
+        if not res then
+            local params = pack(...)
+            local newf = function() return f(unpack(params, 1, params.n)) end
+            co = coroutine.create(newf)
+        end
+        coromap[co] = current
+        return performResume(err, co, ...)
     end
-    coromap[co] = (running() or "mainthread")
-    return performResume(err, co, ...)
 end
 
 local function corunning(coro)
@@ -84,10 +101,6 @@ end
 -------------------------------------------------------------------------------
 -- Implements pcall with coroutines
 -------------------------------------------------------------------------------
-
-local function id(trace, ...)
-  return ...
-end
 
 function copcall(f, ...)
     return coxpcall(f, id, ...)

--- a/src/coxpcall.lua
+++ b/src/coxpcall.lua
@@ -76,8 +76,7 @@ function coxpcall(f, err, ...)
     else
         local res, co = oldpcall(coroutine.create, f)
         if not res then
-            local params = pack(...)
-            local newf = function() return f(unpack(params, 1, params.n)) end
+            local newf = function(...) return f(...) end
             co = coroutine.create(newf)
         end
         coromap[co] = current

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -1,0 +1,256 @@
+#!/usr/bin/env lua
+
+package.path = "../src/?.lua;./src/?.lua"
+local M = require("coxpcall")
+
+local count, errortable = 0, {}
+
+-- test helper functions
+local function assert(ok, ...)
+  if not ok then
+    local msg = ...
+    error(msg == nil and "assertion failed" or msg, 0)
+  else
+    return ok, ...
+  end
+end
+
+local function error_is(f, xmsg)
+  local ok, msg = pcall(f)
+  assert(ok == false, "function did not raise an error")
+  assert(msg == xmsg,
+         "error message not as expected:\n\t"..tostring(msg))
+  count = count + 1
+end
+
+local function error_matches(f, pat)
+  local ok, msg = pcall(f)
+  assert(ok == false, "function did not raise an error")
+  assert(type(msg) == "string",
+         "error message is not a string:\n\t"..type(msg))
+  assert(msg:match(pat),
+         "error message didn't match pattern:\n\t"..pat.."\n\t"..msg)
+  count = count + 1
+end
+
+local function succeeds(f)
+  local ok, msg = pcall(f)
+  assert(ok, "function raised an error\n\t:"..tostring(msg))
+  count = count + 1
+end
+
+local function succeeds_with(f, xrets)
+  local function packrets(ok, ...)
+    return ok, { n=select("#", ...), ... }
+  end
+  local ok, rets = packrets(pcall(f))
+  assert(ok, "function raised an error\n\t:"..tostring(rets[1]))
+  assert(rets.n == xrets.n or #xrets,
+         "unexpected number of return values: "..rets.n..
+         " (expected: "..(xrets.n or #xrets)..")")
+  for i = 1, rets.n do
+    assert(rets[i] == xrets[i],
+           "unexpected return value no. "..i.." ("..
+           tostring(rets[i])..", expected: "..tostring(xrets[i])..")")
+  end
+  count = count + 1
+end
+
+local function traceback()
+  return "XXX"
+end
+
+
+
+-- the tests:
+
+-- co(x)pcall from main thread
+succeeds_with(function()
+  return M.pcall(function(...)
+    return ...
+  end, 1, 2, 3)
+end, { true, 1, 2, 3 })
+
+succeeds_with(function()
+  return M.xpcall(function()
+    return 1, 2, 3
+  end, debug.traceback)
+end, { true, 1, 2, 3 })
+
+error_matches(function()
+  return assert(M.pcall(function(...)
+    error("ARGH", 0)
+  end, 1, 2, 3))
+end, "ARGH")
+
+error_is(function()
+  return assert(M.pcall(function(...)
+    error(errortable, 0)
+  end, 1, 2, 3))
+end, errortable)
+
+error_matches(function()
+  return assert(M.xpcall(function()
+    error("ARGH", 0)
+  end, debug.traceback))
+end, "ARGH")
+
+error_is(function()
+  return assert(M.xpcall(function()
+    error(errortable, 0)
+  end, debug.traceback))
+end, errortable)
+
+error_matches(function()
+  return assert(M.xpcall(function()
+    error("ARGH", 0)
+  end, traceback))
+end, "XXX")
+
+error_matches(function()
+  return assert(M.pcall(rawset))
+end, "bad argument")
+
+
+-- co(x)pcall from within coroutine (without yielding)
+succeeds_with(coroutine.wrap(function()
+  return M.pcall(function(...)
+    return ...
+  end, 1, 2, 3)
+end), { true, 1, 2, 3 })
+
+succeeds_with(coroutine.wrap(function()
+  return M.xpcall(function()
+    return 1, 2, 3
+  end, debug.traceback)
+end), { true, 1, 2, 3 })
+
+error_matches(coroutine.wrap(function()
+  return assert(M.pcall(function(...)
+    error("ARGH", 0)
+  end, 1, 2, 3))
+end), "ARGH")
+
+error_is(coroutine.wrap(function()
+  return assert(M.pcall(function(...)
+    error(errortable, 0)
+  end, 1, 2, 3))
+end), errortable)
+
+error_matches(coroutine.wrap(function()
+  return assert(M.xpcall(function()
+    error("ARGH", 0)
+  end, debug.traceback))
+end), "ARGH")
+
+error_is(coroutine.wrap(function()
+  return assert(M.xpcall(function()
+    error(errortable, 0)
+  end, debug.traceback))
+end), errortable)
+
+error_matches(coroutine.wrap(function()
+  return assert(M.xpcall(function()
+    error("ARGH", 0)
+  end, traceback))
+end), "XXX")
+
+error_matches(coroutine.wrap(function()
+  return assert(M.pcall(rawset))
+end), "bad argument")
+
+
+-- co(x)pcall from within coroutine (with yielding)
+succeeds_with(function()
+  local f = coroutine.wrap(function(...)
+    return M.pcall(function(...)
+      coroutine.yield()
+      return ...
+    end, ...)
+  end)
+  f(1, 2, 3)
+  return f()
+end, { true, 1, 2, 3 })
+
+succeeds_with(function()
+  local f = coroutine.wrap(function()
+    return M.xpcall(function()
+      coroutine.yield()
+      return 1, 2, 3
+    end, debug.traceback)
+  end)
+  f()
+  return f()
+end, { true, 1, 2, 3 })
+
+error_matches(function()
+  local f = coroutine.wrap(function(...)
+    return assert(M.pcall(function(...)
+      coroutine.yield()
+      error("ARGH", 0)
+    end, ...))
+  end)
+  f( 1, 2, 3)
+  return f()
+end, "ARGH")
+
+error_is(function()
+  local f = coroutine.wrap(function(...)
+    return assert(M.pcall(function(...)
+      coroutine.yield()
+      error(errortable, 0)
+    end, ...))
+  end)
+  f( 1, 2, 3)
+  return f()
+end, errortable)
+
+error_matches(function()
+  local f = coroutine.wrap(function()
+    return assert(M.xpcall(function()
+      coroutine.yield()
+      error("ARGH", 0)
+    end, debug.traceback))
+  end)
+  f()
+  return f()
+end, "ARGH")
+
+error_is(function()
+  local f = coroutine.wrap(function()
+    return assert(M.xpcall(function()
+      coroutine.yield()
+      error(errortable, 0)
+    end, debug.traceback))
+  end)
+  f()
+  return f()
+end, errortable)
+
+error_matches(function()
+  local f = coroutine.wrap(function()
+    return assert(M.xpcall(function()
+      coroutine.yield()
+      error("ARGH", 0)
+    end, traceback))
+  end)
+  f()
+  return f()
+end, "XXX")
+
+
+-- running
+succeeds(function()
+  local co = coroutine.create(function()
+    local _,c2 = M.pcall(M.running)
+    local _,c3 = M.xpcall(M.running, debug.traceback)
+    return c2, c3
+  end)
+  local _, r1, r2 = assert(coroutine.resume(co))
+  assert(r1 == co, "running returned wrong thread")
+  assert(r2 == co, "running returned wrong thread")
+end)
+
+
+print("OK", count)
+


### PR DESCRIPTION
Use native `(x)pcall` if possible to improve performance in the most common use case (i.e. `co(x)pcall` is called from the main thread). This makes coxpcall much more viable for use in other libraries (see e.g. https://github.com/diegonehab/luasocket/issues/156#issuecomment-183770494)
